### PR TITLE
Add harness example with tests and CI

### DIFF
--- a/.github/workflows/harness-ci.yaml
+++ b/.github/workflows/harness-ci.yaml
@@ -1,0 +1,27 @@
+name: Harness CI
+
+on:
+  push:
+    paths:
+      - 'examples/harness/**'
+      - '.github/workflows/harness-ci.yaml'
+  pull_request:
+    paths:
+      - 'examples/harness/**'
+      - '.github/workflows/harness-ci.yaml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r examples/harness/requirements.txt
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+        working-directory: examples/harness

--- a/examples/harness/.pre-commit-config.yaml
+++ b/examples/harness/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.2
+    hooks:
+      - id: ruff
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        pass_filenames: false
+        language: system
+        types: [python]

--- a/examples/harness/README.md
+++ b/examples/harness/README.md
@@ -1,0 +1,24 @@
+# Harness Example
+
+This example demonstrates simple helper functions that call the OpenAI API and an MCP server.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+pre-commit install
+```
+
+## Running Checks
+
+Run all linters and tests with:
+
+```bash
+pre-commit run --all-files
+```
+
+You can also run the tests directly using `pytest`:
+
+```bash
+pytest
+```

--- a/examples/harness/harness.py
+++ b/examples/harness/harness.py
@@ -1,0 +1,17 @@
+import openai
+import requests
+
+
+def get_openai_response(prompt: str, model: str = "gpt-3.5-turbo") -> str:
+    """Get a completion from OpenAI."""
+    response = openai.ChatCompletion.create(
+        model=model, messages=[{"role": "user", "content": prompt}]
+    )
+    return response["choices"][0]["message"]["content"]
+
+
+def get_mcp_response(prompt: str, url: str) -> str:
+    """Send a prompt to an MCP endpoint and return the text response."""
+    resp = requests.post(url, json={"prompt": prompt}, timeout=10)
+    resp.raise_for_status()
+    return resp.json()["response"]

--- a/examples/harness/requirements.txt
+++ b/examples/harness/requirements.txt
@@ -1,0 +1,6 @@
+openai
+requests
+pytest
+black
+ruff
+pre-commit

--- a/examples/harness/tests/test_harness.py
+++ b/examples/harness/tests/test_harness.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import harness
+
+
+@patch("harness.openai.ChatCompletion.create")
+def test_get_openai_response(mock_create):
+    mock_create.return_value = {"choices": [{"message": {"content": "hi"}}]}
+    assert harness.get_openai_response("hello") == "hi"
+    mock_create.assert_called_once()
+
+
+@patch("harness.requests.post")
+def test_get_mcp_response(mock_post):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "mcp"}
+    mock_resp.raise_for_status.return_value = None
+    mock_post.return_value = mock_resp
+
+    assert harness.get_mcp_response("hi", "http://mcp") == "mcp"
+    mock_post.assert_called_once_with("http://mcp", json={"prompt": "hi"}, timeout=10)


### PR DESCRIPTION
## Summary
- add `harness` example with helper functions
- provide unit tests mocking OpenAI and MCP
- run black, ruff and pytest via pre-commit
- document usage in example README
- run checks in CI when harness code changes

## Testing
- `pre-commit run --config examples/harness/.pre-commit-config.yaml --files examples/harness/harness.py examples/harness/tests/test_harness.py examples/harness/README.md examples/harness/requirements.txt examples/harness/__init__.py .github/workflows/harness-ci.yaml -v`


------
https://chatgpt.com/codex/tasks/task_b_685e4141c134832d834d6bb30935a9f2